### PR TITLE
Added path strip down to support new self-contained Rust Windows installation

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -4,7 +4,7 @@
     "syntax": "Packages/Makefile/Make.build-language",
     "windows":
     {
-        "path": "C:/Rust/bin"
+        "path": "C:\Program Files (x86)\Rust"
     },
 
     "variants": [

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -2,6 +2,10 @@
     "cmd": ["cargo", "build"],
     "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
     "syntax": "Packages/Makefile/Make.build-language",
+    "windows":
+    {
+        "path": "C:/Rust/bin"
+    },
 
     "variants": [
         {

--- a/Rust.sublime-build
+++ b/Rust.sublime-build
@@ -6,6 +6,10 @@
     {
         "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
     },
+    "windows":
+    {
+        "path": "C:/Rust/bin"
+    },
 	
     "variants": [
         { 	

--- a/Rust.sublime-build
+++ b/Rust.sublime-build
@@ -8,7 +8,7 @@
     },
     "windows":
     {
-        "path": "C:/Rust/bin"
+        "path": "C:\Program Files (x86)\Rust"
     },
 	
     "variants": [


### PR DESCRIPTION
From https://github.com/rust-lang/rust/wiki/Using-Rust-on-Windows:

*Rust compiler uses gcc as a linker driver, and will search for it in the system PATH before searching in the private directory. This means that any other versions found on PATH will override the one bundled with Rust, and may cause linking errors if they aren't compatible. The solution is to strip down the PATH in the console session used to launch rustc.*