### PR TITLE
Fix lifetime parsing

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,5 @@
+[
+  { "keys": ["'"], "command": "insert_snippet", "args": {"contents": "'"}, "context":
+    [{ "key": "selector", "operator": "equal", "operand": "source.rust" }]
+  }
+]

--- a/Rust.JSON-tmLanguage
+++ b/Rust.JSON-tmLanguage
@@ -151,7 +151,7 @@
       ]
     },
     "rust_ref_lifetime": {
-      "match": "&(\\'([a-zA-Z_][a-zA-Z0-9_]*))\\b",
+      "match": "(&\\'([a-zA-Z_][a-zA-Z0-9_]*)(?!\\'))\\b",
       "captures": {
         "1": { "name": "storage.modifier.lifetime.source.rust" },
         "2": { "name": "entity.name.lifetime.source.rust" }
@@ -159,7 +159,7 @@
     },
     "rust_lifetime": {
       "name": "storage.modifier.lifetime.source.rust",
-      "match": "\\'([a-zA-Z_][a-zA-Z0-9_]*)[^\\']\\b",
+      "match": "\\'([a-zA-Z_][a-zA-Z0-9_]*)(?!\\')\\b",
       "captures": {
         "1": { "name": "entity.name.lifetime.source.rust" }
       }

--- a/Rust.tmLanguage
+++ b/Rust.tmLanguage
@@ -334,7 +334,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\'([a-zA-Z_][a-zA-Z0-9_]*)[^\']\b</string>
+			<string>\'([a-zA-Z_][a-zA-Z0-9_]*)(?!\')\b</string>
 			<key>name</key>
 			<string>storage.modifier.lifetime.source.rust</string>
 		</dict>
@@ -354,7 +354,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>&amp;(\'([a-zA-Z_][a-zA-Z0-9_]*))\b</string>
+			<string>(&amp;\'([a-zA-Z_][a-zA-Z0-9_]*)(?!\'))\b</string>
 		</dict>
 		<key>rust_self</key>
 		<dict>


### PR DESCRIPTION
* Added negative lookahead for `'` after the lifetime name, instead of matching for _not_ `'`. This gives correct highlighting for character literals, and fixes two lifetime highligting bugs;
  1. the case where the lifetime only has one character literal, and does not get highlighted at all, and 
  2. the case where the last character in the lifetime gets highlighted as a keyword.
* Moved the `&` inside the first paranthesis for `rust_ref_lifetime`, this gives storage-highlighting for the `&`. As a side note, it seams like the entire `rust_ref_lifetime` repository entry might be redundant, and can be removed entierly. 
* Added the keybinding for disabling single quote auto-pairing to the Default keymap, as suggested by #26 .