### PR TITLE
Add cargo test build command

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -7,6 +7,10 @@
         {
             "cmd": ["cargo", "run"],
             "name": "Run"
+        },
+        {
+            "cmd": ["cargo", "test"],
+            "name": "Test"
         }
     ]
 }


### PR DESCRIPTION
I noticed there was no build command to run tests with Cargo. It's a trivial change, but I figured others would find it useful.