### PR TITLE
Remove Left and Right keywords

### DIFF
--- a/Rust.tmLanguage
+++ b/Rust.tmLanguage
@@ -139,7 +139,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(true|false|Some|None|Left|Right|Ok|Err)\b</string>
+			<string>\b(true|false|Some|None|Ok|Err)\b</string>
 			<key>name</key>
 			<string>constant.language.source.rust</string>
 		</dict>


### PR DESCRIPTION
Both was removed well over a year ago

https://github.com/rust-lang/rust/pull/11149