### PR TITLE
Support for macro highlighting. Both definition and invocation.

### DIFF
--- a/Rust.JSON-tmLanguage
+++ b/Rust.JSON-tmLanguage
@@ -41,6 +41,14 @@
             "2": {"name": "support"}
         }
     },
+    {
+      "name": "meta.macro.source.rust",
+      "match": "\\b(macro_rules!)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?:\\{)",
+      "captures": {
+        "1": {"name": "keyword.source.rust"},
+        "2": {"name": "entity.name.macro.source.rust"}
+      }
+    },
     {"name": "keyword.source.rust",
      "match": "\\b(as|box|break|claim|const|continue|copy|Copy|crate|do|drop|else|extern|for|if|impl|in|let|loop|match|mod|mut|Owned|priv|pub|pure|ref|return|unsafe|use|while|mod|Send|static|trait|struct|enum|type|where)\\b"
     },
@@ -96,6 +104,9 @@
     },
     {"name": "support.function.rust",
      "match": "\\b(\\w+)\\b(?=\\()"
+    },
+    {"name": "support.macro.rust",
+     "match": "\\b(\\w+!)(?=\\()"
     },
     {"name": "meta.namespace-block.rust",
      "match": "\\b(\\w+)::"

--- a/Rust.tmLanguage
+++ b/Rust.tmLanguage
@@ -75,6 +75,25 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
+					<string>entity.name.macro.source.rust</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>\b(macro_rules!)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:\{)</string>
+			<key>name</key>
+			<string>meta.macro.source.rust</string>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.source.rust</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
 					<string>keyword.source.rust</string>
 				</dict>
 				<key>3</key>
@@ -139,7 +158,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(true|false|Some|None|Ok|Err)\b</string>
+			<string>\b(true|false|Some|None|Left|Right|Ok|Err)\b</string>
 			<key>name</key>
 			<string>constant.language.source.rust</string>
 		</dict>
@@ -233,6 +252,12 @@
 			<string>\b(\w+)\b(?=\()</string>
 			<key>name</key>
 			<string>support.function.rust</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(\w+!)(?=\()</string>
+			<key>name</key>
+			<string>support.macro.rust</string>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
This adds highlight support for macro invocation:

```
assert_eq!(true);
```

and macro definition:

```
macro_rules point! {
...
}
```